### PR TITLE
Fix path handling in Makefile install/uninstall rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,8 @@ endif
 install:
 	mkdir -p $(DESTDIR)$(PREFIX)/bin
 	for script in bin/*; do \
-		cp -f $$script $(DESTDIR)$(PREFIX)/bin/; \
-		chmod 755 $(DESTDIR)$(PREFIX)/$$script; \
+	cp -f $$script $(DESTDIR)$(PREFIX)/bin/; \
+	chmod 755 $(DESTDIR)$(PREFIX)/bin/$$(basename $$script); \
 	done
 	mkdir -p $(DESTDIR)$(MANPREFIX)/man1
 	cp -f mcbash.1 $(DESTDIR)$(MANPREFIX)/man1/mcbash.1
@@ -21,15 +21,15 @@ install:
 	cp -f mcbash.conf /etc/mcbash.conf; \
 	chmod 644 /etc/mcbash.conf; \
 	for users in /home/*; do \
-		if mkdir -p /$$users/.mcbash; then \
-			cp -f mcbash.conf /$$users/.mcbash/mcbash.conf; \
-			chmod 777 /$$users/.mcbash/mcbash.conf; \
-		fi;\
+	if mkdir -p /$$users/.mcbash; then \
+	cp -f mcbash.conf /$$users/.mcbash/mcbash.conf; \
+	chmod 777 /$$users/.mcbash/mcbash.conf; \
+	fi;\
 	done
 
 uninstall:
 	for script in bin/*; do \
-		rm -f $(DESTDIR)$(PREFIX)/$$script; \
+	rm -f $(DESTDIR)$(PREFIX)/bin/$$(basename $$script); \
 	done
 	rm -rf $(DESTDIR)$(PREFIX)/share/mcbash
 	rm -f $(DESTDIR)$(MANPREFIX)/man1/mcbash.1


### PR DESCRIPTION
## Summary
- ensure scripts installed with correct permissions by using basename in Makefile
- uninstall rule removes scripts from expected bin directory

## Testing
- `make -n install | head -n 20`
- `make -n uninstall | head -n 20`
- `bash -n bin/mcbash`


------
https://chatgpt.com/codex/tasks/task_e_68af6011ff14832798c255daa88e5367