### PR TITLE
Support system/project config and add embedded defaults to bin/mcbash

### DIFF
--- a/bin/mcbash
+++ b/bin/mcbash
@@ -24,16 +24,30 @@ done
 
 # Loading config file
 config_file=$HOME/.mcbash/mcbash.conf
+system_config_file=/etc/mcbash.conf
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+project_config_file="$script_dir/../mcbash.conf"
 
 if [[ -f $config_file ]]; then
 	source "$config_file"
+elif [[ -f $system_config_file ]]; then
+	source "$system_config_file"
+elif [[ -f $project_config_file ]]; then
+	source "$project_config_file"
 else
-	if [[ -f "/etc/mcbash.conf" ]]; then
-		source "/etc/mcbash.conf"
-	else
-		echo -e "Config file not found. This can cause weird behaviors.\nmcbash.conf should be placed here : $config_file"
-	fi
+	echo -e "Config file not found. Falling back to embedded defaults.\nmcbash.conf should be placed here : $config_file"
 fi
+
+# Embedded fallback defaults (used when config file is missing or incomplete)
+: "${destination:=$HOME/.mcbash}"
+: "${default_request_delay:=2}"
+: "${default_timebreak:=0}"
+: "${default_timebreak_duration:=10}"
+: "${default_stopping:=0}"
+: "${default_timeout:=5}"
+: "${default_first_mac:=00:1A:79:00:00:00}"
+: "${default_last_mac:=00:1A:79:FF:FF:FF}"
+: "${avoid_parameters:=false}"
 
 [ -d $destination ] || mkdir -p "$destination" &> /dev/null || \
 	echo -e "${_BLUE}Can't create saving directory to $destination.\nPlease be sure you have permissions.\nValid MAC addresses will not be stored.${_RESET}"


### PR DESCRIPTION
### Motivation
- Ensure `mcbash` finds configuration in multiple locations and falls back to sane defaults when no config file is present to avoid runtime errors.

### Description
- Add `script_dir` detection via `BASH_SOURCE` and a `project_config_file` next to the script, and introduce `system_config_file=/etc/mcbash.conf` to extend the config search order.
- Change config loading to check `$HOME/.mcbash/mcbash.conf`, then `/etc/mcbash.conf`, then the project-local config, and update the missing-config message to indicate embedded defaults will be used.
- Add embedded fallback defaults using parameter expansion for variables such as `destination`, `default_request_delay`, `default_timebreak`, `default_timebreak_duration`, `default_stopping`, `default_timeout`, `default_first_mac`, `default_last_mac`, and `avoid_parameters`.

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8119f46208327994da43938a46d09)